### PR TITLE
Fix NoMethodError undefined method call for Hash

### DIFF
--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -23,7 +23,7 @@ module CapEC2
     end
 
     def tag_value(instance, key)
-      instance.tags.find({}) { |t| t[:key] == key.to_s }[:value]
+      instance.tags.find(-> { {} }) { |t| t[:key] == key.to_s }[:value]
     end
 
     def self.contact_point_mapping


### PR DESCRIPTION
Enumerable#find expects a callable object for its `ifnone` parameter.